### PR TITLE
chore: promote golang-http to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-production/golang-http/golang-http-0.0.5-release.yaml
+++ b/config-root/namespaces/jx-production/golang-http/golang-http-0.0.5-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-13T13:03:04Z"
+  creationTimestamp: "2021-01-14T08:14:35Z"
   deletionTimestamp: null
-  name: 'golang-http-0.0.4'
+  name: 'golang-http-0.0.5'
   namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.4
-      sha: 16dd2800f68e546facaa3cae60c7ea236e054413
+        chore: release 0.0.5
+      sha: c680bb3c114b73a2c4e2b91553f0e70fb6a02e79
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 13995cb547e37926c2ec1e1302a7093f6a349149
+      sha: 4ab4b62a7692cede6e2c2f8fcba57f3bc8af3010
     - author:
         email: gil@tikalk.com
         name: gilShin
@@ -37,12 +37,12 @@ spec:
       committer:
         email: noreply@github.com
         name: GitHub
-      message: Update curlloop.sh
-      sha: 0f4cbf53bb990f89f57167e2bce7258639449c1c
+      message: Update main.go
+      sha: a968ebc7e376ccb27d14ab4f30feb34dd1680920
   gitHttpUrl: https://github.com/gilShin/golang-http
   gitOwner: gilShin
   gitRepository: golang-http
   name: 'golang-http'
-  releaseNotesURL: https://github.com/gilShin/golang-http/releases/tag/v0.0.4
-  version: v0.0.4
+  releaseNotesURL: https://github.com/gilShin/golang-http/releases/tag/v0.0.5
+  version: v0.0.5
 status: {}

--- a/config-root/namespaces/jx-production/golang-http/golang-http-golang-http-deploy.yaml
+++ b/config-root/namespaces/jx-production/golang-http/golang-http-golang-http-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: golang-http-golang-http
   labels:
     draft: draft-app
-    chart: "golang-http-0.0.4"
+    chart: "golang-http-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: golang-http-golang-http
       containers:
         - name: golang-http
-          image: "10.98.57.81/gilshin/golang-http:0.0.4"
+          image: "10.98.57.81/gilshin/golang-http:0.0.5"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.4
+              value: 0.0.5
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-production/golang-http/golang-http-svc.yaml
+++ b/config-root/namespaces/jx-production/golang-http/golang-http-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: golang-http
   labels:
-    chart: "golang-http-0.0.4"
+    chart: "golang-http-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-0.0.5-release.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-0.0.5-release.yaml
@@ -1,0 +1,48 @@
+# Source: golang-http/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-14T08:14:35Z"
+  deletionTimestamp: null
+  name: 'golang-http-0.0.5'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.5
+      sha: c680bb3c114b73a2c4e2b91553f0e70fb6a02e79
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 4ab4b62a7692cede6e2c2f8fcba57f3bc8af3010
+    - author:
+        email: gil@tikalk.com
+        name: gilShin
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update main.go
+      sha: a968ebc7e376ccb27d14ab4f30feb34dd1680920
+  gitHttpUrl: https://github.com/gilShin/golang-http
+  gitOwner: gilShin
+  gitRepository: golang-http
+  name: 'golang-http'
+  releaseNotesURL: https://github.com/gilShin/golang-http/releases/tag/v0.0.5
+  version: v0.0.5
+status: {}

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-deploy.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: golang-http/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: golang-http-golang-http
+  labels:
+    draft: draft-app
+    chart: "golang-http-0.0.5"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: golang-http-golang-http
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: golang-http-golang-http
+    spec:
+      serviceAccountName: golang-http-golang-http
+      containers:
+        - name: golang-http
+          image: "10.98.57.81/gilshin/golang-http:0.0.5"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.5
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-sa.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-sa.yaml
@@ -1,0 +1,8 @@
+# Source: golang-http/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: golang-http-golang-http
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-ingress.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: golang-http/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: golang-http
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: golang-http
+              servicePort: 80
+      host: golang-http-jx-staging.192.168.99.100.nip.io

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-svc.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-svc.yaml
@@ -1,0 +1,21 @@
+# Source: golang-http/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: golang-http
+  labels:
+    chart: "golang-http-0.0.5"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: golang-http-golang-http

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -4,5 +4,6 @@ helmfiles:
 - path: helmfiles/secret-infra/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
 - path: helmfiles/jx-production/helmfile.yaml
+- path: helmfiles/jx-staging/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/golang-http
-  version: 0.0.4
+  version: 0.0.5
   name: golang-http
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/golang-http
-  version: 0.0.4
+  version: 0.0.5
   name: golang-http
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote golang-http to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge