### PR TITLE
chore: promote golang-http to version 0.0.6

### DIFF
--- a/config-root/namespaces/jx-production/golang-http/golang-http-0.0.6-release.yaml
+++ b/config-root/namespaces/jx-production/golang-http/golang-http-0.0.6-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-14T08:14:35Z"
+  creationTimestamp: "2021-01-14T10:23:36Z"
   deletionTimestamp: null
-  name: 'golang-http-0.0.5'
+  name: 'golang-http-0.0.6'
   namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.5
-      sha: c680bb3c114b73a2c4e2b91553f0e70fb6a02e79
+        chore: release 0.0.6
+      sha: ced045251a99b793b1fbd456660612e32788e0c0
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,20 +29,21 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 4ab4b62a7692cede6e2c2f8fcba57f3bc8af3010
+      sha: 2012ba5dfb4483e5aaea3098f70f528ff4eb83d7
     - author:
-        email: gil@tikalk.com
-        name: gilShin
+        email: gil@anodot.com
+        name: Gil Shinar
       branch: master
       committer:
-        email: noreply@github.com
-        name: GitHub
-      message: Update main.go
-      sha: a968ebc7e376ccb27d14ab4f30feb34dd1680920
+        email: gil@anodot.com
+        name: Gil Shinar
+      message: |
+        test laptop pr
+      sha: a48af77254447d8a1d769bf4dbc85006b113e1e3
   gitHttpUrl: https://github.com/gilShin/golang-http
   gitOwner: gilShin
   gitRepository: golang-http
   name: 'golang-http'
-  releaseNotesURL: https://github.com/gilShin/golang-http/releases/tag/v0.0.5
-  version: v0.0.5
+  releaseNotesURL: https://github.com/gilShin/golang-http/releases/tag/v0.0.6
+  version: v0.0.6
 status: {}

--- a/config-root/namespaces/jx-production/golang-http/golang-http-golang-http-deploy.yaml
+++ b/config-root/namespaces/jx-production/golang-http/golang-http-golang-http-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: golang-http-golang-http
   labels:
     draft: draft-app
-    chart: "golang-http-0.0.5"
+    chart: "golang-http-0.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: golang-http-golang-http
       containers:
         - name: golang-http
-          image: "10.98.57.81/gilshin/golang-http:0.0.5"
+          image: "10.98.57.81/gilshin/golang-http:0.0.6"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.5
+              value: 0.0.6
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-production/golang-http/golang-http-svc.yaml
+++ b/config-root/namespaces/jx-production/golang-http/golang-http-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: golang-http
   labels:
-    chart: "golang-http-0.0.5"
+    chart: "golang-http-0.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-0.0.6-release.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-0.0.6-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-14T08:14:35Z"
+  creationTimestamp: "2021-01-14T10:23:36Z"
   deletionTimestamp: null
-  name: 'golang-http-0.0.5'
+  name: 'golang-http-0.0.6'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.5
-      sha: c680bb3c114b73a2c4e2b91553f0e70fb6a02e79
+        chore: release 0.0.6
+      sha: ced045251a99b793b1fbd456660612e32788e0c0
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,20 +29,21 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 4ab4b62a7692cede6e2c2f8fcba57f3bc8af3010
+      sha: 2012ba5dfb4483e5aaea3098f70f528ff4eb83d7
     - author:
-        email: gil@tikalk.com
-        name: gilShin
+        email: gil@anodot.com
+        name: Gil Shinar
       branch: master
       committer:
-        email: noreply@github.com
-        name: GitHub
-      message: Update main.go
-      sha: a968ebc7e376ccb27d14ab4f30feb34dd1680920
+        email: gil@anodot.com
+        name: Gil Shinar
+      message: |
+        test laptop pr
+      sha: a48af77254447d8a1d769bf4dbc85006b113e1e3
   gitHttpUrl: https://github.com/gilShin/golang-http
   gitOwner: gilShin
   gitRepository: golang-http
   name: 'golang-http'
-  releaseNotesURL: https://github.com/gilShin/golang-http/releases/tag/v0.0.5
-  version: v0.0.5
+  releaseNotesURL: https://github.com/gilShin/golang-http/releases/tag/v0.0.6
+  version: v0.0.6
 status: {}

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-deploy.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: golang-http-golang-http
   labels:
     draft: draft-app
-    chart: "golang-http-0.0.5"
+    chart: "golang-http-0.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: golang-http-golang-http
       containers:
         - name: golang-http
-          image: "10.98.57.81/gilshin/golang-http:0.0.5"
+          image: "10.98.57.81/gilshin/golang-http:0.0.6"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.5
+              value: 0.0.6
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-svc.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: golang-http
   labels:
-    chart: "golang-http-0.0.5"
+    chart: "golang-http-0.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/golang-http
-  version: 0.0.5
+  version: 0.0.6
   name: golang-http
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/golang-http
-  version: 0.0.5
+  version: 0.0.6
   name: golang-http
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote golang-http to version 0.0.6

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge