### PR TITLE
chore: promote rails-shopping-cart to version 0.0.4

### DIFF
--- a/config-root/namespaces/jx-staging/rails-shopping-cart/rails-shopping-cart-0.0.4-release.yaml
+++ b/config-root/namespaces/jx-staging/rails-shopping-cart/rails-shopping-cart-0.0.4-release.yaml
@@ -1,0 +1,69 @@
+# Source: rails-shopping-cart/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-19T12:09:23Z"
+  deletionTimestamp: null
+  name: 'rails-shopping-cart-0.0.4'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.4
+      sha: a8d3621197333edac1c7f6d7cb293ec9ce6dc7b2
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 3dc6f55e475349f845f309393005b57bb7ca1961
+    - author:
+        email: gil@anodot.com
+        name: Gil Shinar
+      branch: master
+      committer:
+        email: gil@anodot.com
+        name: Gil Shinar
+      message: |
+        chore: Jenkins X build pack
+      sha: 0fd8d41c7a8372c3ad022596fedc2b3d8501fac5
+    - author:
+        email: contact@mauromorales.com
+        name: Mauro Morales
+      branch: master
+      committer:
+        email: contact@mauromorales.com
+        name: Mauro Morales
+      message: |
+        Upgrade Rails to 5.0.7
+      sha: 34ed3df83085a7d541d5c72d97d674f2b0f0c913
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        remove build pack generated stuff
+      sha: 2712fbe9e942a455925c9dc974ba72153d7d8053
+  gitHttpUrl: https://github.com/gilShin/rails-shopping-cart
+  gitOwner: gilShin
+  gitRepository: rails-shopping-cart
+  name: 'rails-shopping-cart'
+  releaseNotesURL: https://github.com/gilShin/rails-shopping-cart/releases/tag/v0.0.4
+  version: v0.0.4
+status: {}

--- a/config-root/namespaces/jx-staging/rails-shopping-cart/rails-shopping-cart-ingress.yaml
+++ b/config-root/namespaces/jx-staging/rails-shopping-cart/rails-shopping-cart-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: rails-shopping-cart/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: rails-shopping-cart
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: rails-shopping-cart
+              servicePort: 80
+      host: rails-shopping-cart-jx-staging.192.168.99.100.nip.io

--- a/config-root/namespaces/jx-staging/rails-shopping-cart/rails-shopping-cart-rails-shopping-cart-deploy.yaml
+++ b/config-root/namespaces/jx-staging/rails-shopping-cart/rails-shopping-cart-rails-shopping-cart-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: rails-shopping-cart/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rails-shopping-cart-rails-shopping-cart
+  labels:
+    draft: draft-app
+    chart: "rails-shopping-cart-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: rails-shopping-cart-rails-shopping-cart
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: rails-shopping-cart-rails-shopping-cart
+    spec:
+      serviceAccountName: rails-shopping-cart-rails-shopping-cart
+      containers:
+        - name: rails-shopping-cart
+          image: "10.98.57.81/gilshin/rails-shopping-cart:0.0.4"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.4
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/rails-shopping-cart/rails-shopping-cart-rails-shopping-cart-sa.yaml
+++ b/config-root/namespaces/jx-staging/rails-shopping-cart/rails-shopping-cart-rails-shopping-cart-sa.yaml
@@ -1,0 +1,8 @@
+# Source: rails-shopping-cart/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rails-shopping-cart-rails-shopping-cart
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/rails-shopping-cart/rails-shopping-cart-svc.yaml
+++ b/config-root/namespaces/jx-staging/rails-shopping-cart/rails-shopping-cart-svc.yaml
@@ -1,0 +1,21 @@
+# Source: rails-shopping-cart/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: rails-shopping-cart
+  labels:
+    chart: "rails-shopping-cart-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: rails-shopping-cart-rails-shopping-cart

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/rails-shopping-cart
   version: 0.0.4
   name: rails-shopping-cart
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: golang-http
   values:
   - jx-values.yaml
+- chart: dev/rails-shopping-cart
+  version: 0.0.4
+  name: rails-shopping-cart
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote rails-shopping-cart to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge