### PR TITLE
chore: promote react-quickstart to version 0.1.2

### DIFF
--- a/config-root/namespaces/jx-production/react-quickstart/react-quickstart-0.1.2-release.yaml
+++ b/config-root/namespaces/jx-production/react-quickstart/react-quickstart-0.1.2-release.yaml
@@ -1,0 +1,48 @@
+# Source: react-quickstart/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-20T10:34:49Z"
+  deletionTimestamp: null
+  name: 'react-quickstart-0.1.2'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.1.2
+      sha: 867084ec55527eed1dbf4c7394bd37a6df8ef749
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: eeb415423599f6b9e292170baa56754a5a4fb390
+    - author:
+        email: gil@tikalk.com
+        name: gilShin
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update README.md
+      sha: 9fe01644afded34f03dc6525748565282e6cc0c1
+  gitHttpUrl: https://github.com/gilShin/react-quickstart
+  gitOwner: gilShin
+  gitRepository: react-quickstart
+  name: 'react-quickstart'
+  releaseNotesURL: https://github.com/gilShin/react-quickstart/releases/tag/v0.1.2
+  version: v0.1.2
+status: {}

--- a/config-root/namespaces/jx-production/react-quickstart/react-quickstart-ingress.yaml
+++ b/config-root/namespaces/jx-production/react-quickstart/react-quickstart-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: react-quickstart/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: react-quickstart
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: react-quickstart
+              servicePort: 80
+      host: react-quickstart-jx-production.192.168.99.100.nip.io

--- a/config-root/namespaces/jx-production/react-quickstart/react-quickstart-react-quickstart-deploy.yaml
+++ b/config-root/namespaces/jx-production/react-quickstart/react-quickstart-react-quickstart-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: react-quickstart/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: react-quickstart-react-quickstart
+  labels:
+    draft: draft-app
+    chart: "react-quickstart-0.1.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: react-quickstart-react-quickstart
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: react-quickstart-react-quickstart
+    spec:
+      serviceAccountName: react-quickstart-react-quickstart
+      containers:
+        - name: react-quickstart
+          image: "10.98.57.81/gilshin/react-quickstart:0.1.2"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.1.2
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-production/react-quickstart/react-quickstart-react-quickstart-sa.yaml
+++ b/config-root/namespaces/jx-production/react-quickstart/react-quickstart-react-quickstart-sa.yaml
@@ -1,0 +1,8 @@
+# Source: react-quickstart/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: react-quickstart-react-quickstart
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/react-quickstart/react-quickstart-svc.yaml
+++ b/config-root/namespaces/jx-production/react-quickstart/react-quickstart-svc.yaml
@@ -1,0 +1,21 @@
+# Source: react-quickstart/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: react-quickstart
+  labels:
+    chart: "react-quickstart-0.1.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: react-quickstart-react-quickstart

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/react-quickstart
   version: 0.1.2
   name: react-quickstart
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: golang-http
   values:
   - jx-values.yaml
+- chart: dev/react-quickstart
+  version: 0.1.2
+  name: react-quickstart
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote react-quickstart to version 0.1.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge