### PR TITLE
chore: promote node-http to version 1.0.1

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -18,5 +18,8 @@ releases:
   name: react-quickstart
   values:
   - jx-values.yaml
+- chart: dev/node-http
+  version: 1.0.1
+  name: node-http
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote node-http to version 1.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge